### PR TITLE
Fault tolerant behaviour in federated requests

### DIFF
--- a/lib/ewdrestChildProcess.js
+++ b/lib/ewdrestChildProcess.js
@@ -181,9 +181,11 @@ var ewdChild = {
         args.params.accessId = destinationObj.accessId;
         //if (rest.body) args.params.ewd_body = rest.body;
         //console.log("***** method: " + rest.method);
-        if (rest.method === 'POST') {
+
+		args.method = rest.method;
+        if ((rest.method === 'POST') || (rest.method === 'PUT')) {
           args.post_data = rest.params;
-          args.method = 'POST';
+          //args.method = 'POST';
         }
 
         client.run(args, function(error, data) {

--- a/lib/ewdrestChildProcess.js
+++ b/lib/ewdrestChildProcess.js
@@ -136,7 +136,7 @@ var EWD = {
       });
     }
     catch(err) {
-      if (ewdChild.traceLevel >= 2) ewdChild.log("Error in requireAndWatch - " + path + " could not be loaded", 2);
+      if (ewdChild.traceLevel >= 2) ewdChild.log("Error in requireAndWatch - " + path + " could not be loaded" + JSON.stringify(err), 2);
     }
     return module;
   },
@@ -332,6 +332,8 @@ var ewdChild = {
           }
           responseObj = {
             type: 'error',
+            // add the site where the request originated, needed for error reporting per site
+            site: request.site,
             error: {
               statusCode: statusCode,
               restCode: restCode,
@@ -339,6 +341,12 @@ var ewdChild = {
             },
             contentType: request.contentType
           };
+          // add multiple to response and change type to request type
+          // this way, processRequest can aggregate properly partial response when site(s) are down
+          if (request.multiple) {
+           responseObj.multiple = request.multiple;
+           responseObj.type = request.type;
+          }
           ewdChild.responseEvent.emit('processResponse', responseObj);
         }
         else {
@@ -956,11 +964,30 @@ var ewdChild = {
           }
         }
       }
+      /* this is replaced by the new code below
       if (responseObj.multiple && responseObj.response) {
         ewdChild.aggregateResponse[type][responseObj.site] = responseObj.response;
         if (completed) {
           responseObj.response = ewdChild.aggregateResponse[type];
         }
+      }
+      */
+      if (responseObj.multiple) {
+       // handle the error for one site: put the error object in the aggregate
+       if (responseObj.error) {
+        ewdChild.aggregateResponse[type][responseObj.site] = {
+         error: responseObj.error
+        };
+        // remove the error from te response object (avoid returning error in aggregate response at top level)
+        delete responseObj.error;
+       }
+       // existing code retained for constructing response object
+       if (responseObj.response) {
+        ewdChild.aggregateResponse[type][responseObj.site] = responseObj.response;
+       }
+       if (completed) {
+        responseObj.response = ewdChild.aggregateResponse[type];
+       }
       }
       /*
       if (completed && ewdChild.extend && ewdChild.extend.onResponse && ewdChild.extend.onResponse[type]) {


### PR DESCRIPTION
- added error details in requireAndWatch, now you see where the errors are when writing your modules
- modified code for returning partial responses on multisite requests (only the site that is down returns an error, avoiding that the complete request fails)

Btw, should these partial multisite responses not be added as a configuration parameter to maintain compatibility for existing users?
