### PR TITLE
Bug fix in sendToSite

### DIFF
--- a/lib/ewdrestChildProcess.js
+++ b/lib/ewdrestChildProcess.js
@@ -366,6 +366,8 @@ var ewdChild = {
       destinationObj = null;
       contentType = null;
       pathArr = null;
+      service = null;
+      serviceObj = null;
       args = null;
       request = null;
       responseObj = null;
@@ -374,6 +376,8 @@ var ewdChild = {
     }
 
     var pathArr;
+    var service;
+    var serviceObj;
     var args;
     var request;
     var responseObj;
@@ -384,6 +388,8 @@ var ewdChild = {
     var contentType = params.contentType || 'application/json';
     if (typeof destinationObj !== 'undefined') {
       pathArr = params.path.split('/');
+      service = pathArr[0] || 'unknownService';
+      serviceObj = ewdChild.service[service] || {};
       ewdjs = destinationObj.ewdjs;
       nvps = params.nvps;
       if (params.nvpsBySite && params.nvpsBySite[params.site]) nvps = params.nvpsBySite[params.site];
@@ -393,9 +399,9 @@ var ewdChild = {
         host: destinationObj.host,
         port: destinationObj.port,
         ssl: destinationObj.ssl,
-        appName: pathArr[0],
+        appName: serviceObj.module || 'unknowModuleName',
         ewdjs: ewdjs,
-        serviceName: pathArr[1],
+        serviceName: serviceObj.service || 'unknowServiceName',
         params: nvps,
         secretKey: destinationObj.secretKey
       };


### PR DESCRIPTION
The meaning of appName and serviceName changed in current (rewritten) version in contrast with version 12. I changed the code according to the REST service documentation and preserving functionality from earlier versions (module and service in service config).
